### PR TITLE
Added methods to allow for manually set font size, measured in dp.

### DIFF
--- a/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToast.java
+++ b/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToast.java
@@ -63,6 +63,11 @@ public class LoadToast {
         return this;
     }
 
+    public LoadToast setTextTypeface(Typeface font){
+        mView.setTextTypeface(font);
+        return this;
+    }
+
     public LoadToast setBackgroundColor(int color){
         mView.setBackgroundColor(color);
         return this;

--- a/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToast.java
+++ b/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToast.java
@@ -2,6 +2,7 @@ package net.steamcrafted.loadtoast;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.Typeface;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -75,6 +76,11 @@ public class LoadToast {
 
     public LoadToast setProgressColor(int color){
         mView.setProgressColor(color);
+        return this;
+    }
+
+    public LoadToast setTextSize(int size){
+        mView.setTextSize(size);
         return this;
     }
 

--- a/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToastView.java
+++ b/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToastView.java
@@ -112,6 +112,10 @@ public class LoadToastView extends View {
         textPaint.setColor(color);
     }
 
+    public void setTextTypeface(Typeface font){
+        textPaint.setTypeface(font);
+    }
+
     public void setBackgroundColor(int color){
         backPaint.setColor(color);
         iconBackPaint.setColor(color);

--- a/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToastView.java
+++ b/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToastView.java
@@ -8,6 +8,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.Log;
@@ -123,6 +124,11 @@ public class LoadToastView extends View {
 
     public void setProgressColor(int color){
         loaderPaint.setColor(color);
+    }
+
+    public void setTextSize(int size){
+        size = dpToPx(size);
+        textPaint.setTextSize(size);
     }
 
     public void show(){


### PR DESCRIPTION
Hi! 

I've added two methods in `LoadToast.java` and `LoadToastView.java` that makes it possible to set a static font size instead of adjusting according to available space. 
The size is measured in dp.

This pull request reflects issue #16.

This is my first pull request, so if I've screwed up I'm sorry!
