### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ lt.setTextColor(Color.RED).setBackgroundColor(Color.GREEN).setProgressColor(Colo
 
 These can be chained as you can see.
 
-#License
+# License
 
 Released under the [Apache 2.0 License](https://github.com/code-mc/loadtoast/blob/master/license.md)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
