### PR TITLE
Add second constructor to pass parent View

### DIFF
--- a/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToast.java
+++ b/loadtoast/src/main/java/net/steamcrafted/loadtoast/LoadToast.java
@@ -3,6 +3,7 @@ package net.steamcrafted.loadtoast;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
+import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
@@ -26,9 +27,13 @@ public class LoadToast {
     private boolean mVisible = false;
     private boolean mReAttached = false;
 
-    public LoadToast(Context context){
+    public LoadToast(Context context, View parentView) {
         mView = new LoadToastView(context);
-        mParentView = (ViewGroup) ((Activity) context).getWindow().getDecorView();
+        mParentView = (ViewGroup) parentView;
+    }
+
+    public LoadToast(Context context) {
+        LoadToast(context, (ViewGroup) ((Activity) context).getWindow().getDecorView());
     }
 
     private void cleanup() {


### PR DESCRIPTION
In some use cases, it is possible that the client wants to define a view that the toast UI should attach to.